### PR TITLE
Feat: add ability to unselect starters in Tracker Library

### DIFF
--- a/src/containers/library/library.svelte
+++ b/src/containers/library/library.svelte
@@ -91,7 +91,15 @@
               installed[tracker.tag] = true;
               Interact.toast(`${tracker.label} added`);
             } else {
-              Interact.toast(`${tracker.label} already installed`);
+              TrackerStore.deleteTracker(tracker);
+              /**
+               * Svelte doesn't trigger render after deleting object property,
+               * so we must reassign `installed` to itself to update the DOM.
+               * See: https://github.com/sveltejs/svelte/issues/3211
+               */
+              delete installed[tracker.tag];
+              installed = installed;
+              Interact.toast(`${tracker.label} removed`);
             }
           }} />
       </div>


### PR DESCRIPTION
I recently discovered Nomie while searching for habit tracking apps and immediately fell in love with this one. Upon onboarding, however, I accidentally selected a few too many starter trackers and was a slightly irritated when clicking a starter a second time did not not remove it.

Thus, I decided to put my programming prowess to the test and implement a fix myself which is this commit. I personally think this is a small yet crucial improvement to the UX.

**Preview:**
<img src="https://user-images.githubusercontent.com/16343560/79152003-54c98400-7d80-11ea-877b-3e695b5fbdc1.gif" height="600" />
